### PR TITLE
Schema validation

### DIFF
--- a/src/classes/guard_struct.py
+++ b/src/classes/guard_struct.py
@@ -68,7 +68,6 @@ class GuardStruct:
         )
         return guard_struct
 
-
     def to_response(self) -> dict:
         response = {"name": self.name, "railspec": self.railspec.to_response()}
         if self.num_reasks is not None:

--- a/src/utils/payload_validator.py
+++ b/src/utils/payload_validator.py
@@ -1,4 +1,3 @@
-import os
 import yaml
 from typing import Dict
 from jsonschema import Draft202012Validator, ValidationError
@@ -22,13 +21,14 @@ guard_validator = Draft202012Validator(
     registry=registry
 )
 
+
 def validate_payload(payload: dict):
     fields = {}
     error: ValidationError
     for error in guard_validator.iter_errors(payload):
         fields[error.json_path] = fields.get(error.json_path, [])
         fields[error.json_path].append(error.message)
-        
+
     if fields:
         raise HttpError(
             400,


### PR DESCRIPTION
Use `jsonschema` library to validate incoming requests against the schemas defined in our Open API Spec.