### PR TITLE
Openinference Instrumentation Proof-Of-Concept

### DIFF
--- a/guardrails_api/app.py
+++ b/guardrails_api/app.py
@@ -65,8 +65,6 @@ def create_app(
     self_endpoint = os.environ.get("SELF_ENDPOINT", f"{host}:{set_port}")
     os.environ["SELF_ENDPOINT"] = self_endpoint
 
-    register_config(config)
-
     app = Flask(__name__)
     app.json = OverrideJsonProvider(app)
 
@@ -83,6 +81,8 @@ def create_app(
     if not otel_is_disabled():
         FlaskInstrumentor().instrument_app(app)
         initialize()
+
+    register_config(config)
 
     # if no pg_host is set, don't set up postgres
     if postgres_is_enabled():

--- a/guardrails_api/otel/traces.py
+++ b/guardrails_api/otel/traces.py
@@ -16,6 +16,7 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
     OTLPSpanExporter as GrpcSpanExporter,
 )
+from openinference.instrumentation.guardrails import GuardrailsInstrumentor
 from guardrails_api.otel.constants import none
 
 
@@ -67,6 +68,9 @@ def initialize_tracer():
         use_batch = os.environ.get("OTEL_PROCESS_IN_BATCH", "true") == "true"
         for exporter in trace_exporters:
             set_span_processors(tracer_provider, exporter, use_batch)
+
+        # Instrument with OpenInference
+        GuardrailsInstrumentor().instrument(tracer_provider=tracer_provider)
 
         # Initialize singleton
         get_tracer()

--- a/guardrails_api/start-dev.sh
+++ b/guardrails_api/start-dev.sh
@@ -1,1 +1,2 @@
-gunicorn --bind 0.0.0.0:8000 --timeout=5 --threads=10 "guardrails_api.app:create_app()" --reload --capture-output --enable-stdio-inheritance
+# TODO: Have to pass the config file to this now or it will blow up.
+gunicorn --bind 0.0.0.0:8000 --timeout=5 --workers=1 "guardrails_api.app:create_app()" --reload --capture-output --enable-stdio-inheritance

--- a/guardrails_api/start.sh
+++ b/guardrails_api/start.sh
@@ -1,1 +1,2 @@
-gunicorn --bind 0.0.0.0:8000 --timeout=5 --threads=10 "guardrails_api.app:create_app()"
+# TODO: Have to pass the config file to this now or it will blow up.
+gunicorn --bind 0.0.0.0:8000 --timeout=5 --workers=1 "guardrails_api.app:create_app()"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["Guardrails", "Guardrails AI", "Guardrails API", "Guardrails API"]
 requires-python = ">= 3.8.1"
 dependencies = [
-    "guardrails-ai>=0.5.0a11",
+    "guardrails-ai>=0.5.0",
     "flask>=3.0.3,<4",
     "Flask-SQLAlchemy>=3.1.1,<4",
     "Flask-Caching>=2.3.0,<3",
@@ -27,6 +27,7 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-grpc>=1.0.0,<2",
     "opentelemetry-exporter-otlp-proto-http>=1.0.0,<2",
     "opentelemetry-instrumentation-flask>=0.12b0,<1",
+    "openinference-instrumentation-guardrails>=0.1.0"
 ]
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-grpc>=1.0.0,<2",
     "opentelemetry-exporter-otlp-proto-http>=1.0.0,<2",
     "opentelemetry-instrumentation-flask>=0.12b0,<1",
-    "openinference-instrumentation-guardrails>=0.1.0"
 ]
 
 [tool.setuptools.dynamic]
@@ -43,6 +42,10 @@ dev = [
     "coverage",
     "pytest-mock",
     "gunicorn>=22.0.0,<23",
+]
+
+openinference = [
+    "openinference-instrumentation-guardrails>=0.1.0"
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This PR adds OpenInference's GuardrailsInstrumentation on top of the exist FlaskInstrumentation for OTEL.  The spans captured by this new instrumentation can be fed to any OTEL-compliant collector including Arize's Phoenix.


### .env file with the OTEL settings I was using
```env
OTEL_PYTHON_TRACER_PROVIDER=sdk_tracer_provider
OTEL_SERVICE_NAME=my-service
OTEL_TRACES_EXPORTER=otlp
OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST="Accept-Encoding,User-Agent,Referer"
OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE="Last-Modified,Content-Type"
OTEL_METRICS_EXPORTER=none
OTEL_EXPORTER_OTLP_PROTOCOL=grpc
OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
```

### Notes on Productionization
1. Since this requires another third party package, we probably want to make this instrumentation optional.  That means switching the dependency to a pip extra, performing an optional import in `guardrails_api/otel/traces.py`, and then only instrumenting when the package is installed.  This pip extra would also need to be reflected in the core guardrails-ai package for users utilizing `guardrails start`.
2. We still need to collaborate with Arize to see how we can/should attach the span attributes that they collect in other instrumentations.  See the notion task for more info: https://www.notion.so/guardrailsai/Arize-integration-4fd0096121094cc2896a6200786fb7b0?pvs=4