### PR TITLE
Enhanced server startup logs (API URL, Docs URL, ect)

### DIFF
--- a/guardrails_api/app.py
+++ b/guardrails_api/app.py
@@ -10,7 +10,8 @@ from opentelemetry.instrumentation.flask import FlaskInstrumentor
 from guardrails_api.clients.postgres_client import postgres_is_enabled
 from guardrails_api.otel import otel_is_disabled, initialize
 from guardrails_api.clients.cache_client import CacheClient
-
+from rich.console import Console
+from rich.rule import Rule
 
 # TODO: Move this to a separate file
 class OverrideJsonProvider(DefaultJSONProvider):
@@ -50,6 +51,9 @@ def register_config(config: Optional[str] = None):
 def create_app(
     env: Optional[str] = None, config: Optional[str] = None, port: Optional[int] = None
 ):
+    # used to print user-facing messages during server startup
+    console = Console()
+
     if os.environ.get("APP_ENVIRONMENT") != "production":
         from dotenv import load_dotenv
 
@@ -96,9 +100,23 @@ def create_app(
     cache_client.initialize(app)
 
     from guardrails_api.blueprints.root import root_bp
-    from guardrails_api.blueprints.guards import guards_bp
+    from guardrails_api.blueprints.guards import guards_bp, guard_client
 
     app.register_blueprint(root_bp)
     app.register_blueprint(guards_bp)
+
+    console.print(
+        f"\n:rocket: Guardrails API is available at {self_endpoint}"
+    )
+    console.print(f":book: Visit {self_endpoint}/docs to see available API endpoints.\n")
+
+    console.print(":green_circle: Active guards and OpenAI compatible endpoints:")
+
+    for g in guard_client.get_guards():
+        g = g.to_dict()
+        console.print(f"- Guard: [bold white]{g.get('name')}[/bold white] {self_endpoint}/guards/{g.get('name')}/openai/v1")
+
+    console.print("")
+    console.print(Rule("[bold grey]Server Logs[/bold grey]", characters="=", style="white"))
 
     return app


### PR DESCRIPTION
## Pull Request Type
 - [ ] Breaking Change
 - [x] Feature
 - [ ] Bug Fix
 - [ ] Non-bug Patch (dependency update, non-production code, etc.)

## Link to Notion Task or Github Issue
https://www.notion.so/guardrailsai/Augment-server-start-messages-7736fec38fbc4fb6a59b0140dbd40171

## Summary of Feature(s)
Added server start console messages including API url, docs url and registered guard names

### New Behaviour
Added server start console messages including API url, docs url and registered guard names

### Notes

- Considered hitting API endpoint to be less coupled to current implementation but if users host and add auth could cause complications
- Considered adding to the Typer start command directly but placing in `create_app` will allow users to see this if they start with gunicorn or other methods

## Dependencies
N/A

https://github.com/user-attachments/assets/3954fe23-08e6-4df7-a975-2b4495791e4c


