### PR TITLE
fix(openai): include id, object, created, model in chat completions response

### DIFF
--- a/guardrails_api/utils/openai.py
+++ b/guardrails_api/utils/openai.py
@@ -1,4 +1,21 @@
+import time
+import uuid
+
 from guardrails.classes import ValidationOutcome
+
+
+def _ensure_openai_fields(response: dict, object_type: str = "chat.completion"):
+    """Ensure the response contains required OpenAI-compatible fields.
+
+    Per the OpenAI API spec, responses must include ``id``, ``object``,
+    ``created``, and ``model``.  When the upstream LLM response already
+    provides these fields they are preserved; otherwise sensible defaults
+    are injected.
+    """
+    response.setdefault("id", f"chatcmpl-{uuid.uuid4().hex}")
+    response.setdefault("object", object_type)
+    response.setdefault("created", int(time.time()))
+    response.setdefault("model", "guardrails")
 
 
 def outcome_to_stream_response(validation_outcome: ValidationOutcome):
@@ -19,6 +36,7 @@ def outcome_to_stream_response(validation_outcome: ValidationOutcome):
     # does this even make sense with a stream? wed need each chunk as theyre emitted
     stream_chunk = stream_chunk_template
     stream_chunk["choices"][0]["delta"]["content"] = validation_outcome.validated_output
+    _ensure_openai_fields(stream_chunk, object_type="chat.completion.chunk")
     return stream_chunk
 
 
@@ -35,6 +53,7 @@ def outcome_to_chat_completion(
         }
     )
     completion = getattr(llm_response, "full_raw_llm_output", completion_template)
+    _ensure_openai_fields(completion)
     completion["guardrails"] = {
         "reask": validation_outcome.reask or None,
         "validation_passed": validation_outcome.validation_passed,

--- a/tests/utils/test_openai.py
+++ b/tests/utils/test_openai.py
@@ -28,6 +28,23 @@ class TestOutcomeToStreamResponse(unittest.TestCase):
         self.assertIsNone(result["guardrails"]["reask"])
         self.assertIsNone(result["guardrails"]["error"])
 
+    def test_outcome_to_stream_response_has_openai_fields(self):
+        """Test that stream response includes required OpenAI-compatible fields."""
+        mock_outcome = Mock()
+        mock_outcome.validated_output = "Test output"
+        mock_outcome.reask = None
+        mock_outcome.validation_passed = True
+        mock_outcome.error = None
+
+        result = outcome_to_stream_response(mock_outcome)
+
+        self.assertIn("id", result)
+        self.assertTrue(result["id"].startswith("chatcmpl-"))
+        self.assertEqual(result["object"], "chat.completion.chunk")
+        self.assertIn("created", result)
+        self.assertIsInstance(result["created"], int)
+        self.assertIn("model", result)
+
     def test_outcome_to_stream_response_with_reask(self):
         """Test stream response with reask."""
         mock_outcome = Mock()
@@ -153,6 +170,54 @@ class TestOutcomeToChatCompletion(unittest.TestCase):
 
         self.assertIn("guardrails", result)
         self.assertEqual(result["choices"][0]["message"]["content"], "Test")
+
+    def test_outcome_to_chat_completion_has_openai_fields_from_fallback(self):
+        """Test that id/object/created/model are injected when missing."""
+        mock_outcome = Mock()
+        mock_outcome.validated_output = "Test"
+        mock_outcome.reask = None
+        mock_outcome.validation_passed = True
+        mock_outcome.error = None
+        mock_outcome.validation_summaries = []
+
+        mock_llm_response = Mock(spec=[])  # No full_raw_llm_output
+
+        result = outcome_to_chat_completion(
+            mock_outcome, mock_llm_response, has_tool_gd_tool_call=False
+        )
+
+        self.assertIn("id", result)
+        self.assertTrue(result["id"].startswith("chatcmpl-"))
+        self.assertEqual(result["object"], "chat.completion")
+        self.assertIn("created", result)
+        self.assertIsInstance(result["created"], int)
+        self.assertIn("model", result)
+
+    def test_outcome_to_chat_completion_preserves_existing_openai_fields(self):
+        """Test that existing id/object/created/model from LLM are preserved."""
+        mock_outcome = Mock()
+        mock_outcome.validated_output = "Test"
+        mock_outcome.reask = None
+        mock_outcome.validation_passed = True
+        mock_outcome.error = None
+        mock_outcome.validation_summaries = []
+
+        mock_llm_response = Mock()
+        mock_llm_response.full_raw_llm_output = {
+            "id": "chatcmpl-original-id",
+            "object": "chat.completion",
+            "created": 1700000000,
+            "model": "gpt-4o-mini",
+            "choices": [{"message": {"content": "original"}}],
+        }
+
+        result = outcome_to_chat_completion(
+            mock_outcome, mock_llm_response, has_tool_gd_tool_call=False
+        )
+
+        self.assertEqual(result["id"], "chatcmpl-original-id")
+        self.assertEqual(result["model"], "gpt-4o-mini")
+        self.assertEqual(result["created"], 1700000000)
 
     def test_outcome_to_chat_completion_with_reask_and_error(self):
         """Test chat completion with reask and error."""


### PR DESCRIPTION
## Summary

The `/guards/{guard_name}/openai/v1/chat/completions` endpoint returns responses missing required OpenAI-compatible fields (`id`, `object`, `created`, `model`), violating the [OpenAI Chat Completions API spec](https://platform.openai.com/docs/api-reference/chat/object).

## Root Cause

Both `outcome_to_chat_completion()` and `outcome_to_stream_response()` in `guardrails_api/utils/openai.py` build response dicts that only include `choices` and `guardrails` keys. When the upstream LLM response (`full_raw_llm_output`) is not available, the fallback template omits all required top-level fields.

## Fix

Added a `_ensure_openai_fields()` helper that uses `dict.setdefault()` to inject `id`, `object`, `created`, and `model` only when they are not already present. This preserves fields from the upstream LLM response when available while ensuring spec compliance in all code paths.

- Non-streaming: `object` = `"chat.completion"`
- Streaming: `object` = `"chat.completion.chunk"`
- `id` format: `chatcmpl-{uuid4}` (matches OpenAI convention)

## Tests

Added 3 new test cases to `tests/utils/test_openai.py`:
- `test_outcome_to_stream_response_has_openai_fields` — stream responses include required fields
- `test_outcome_to_chat_completion_has_openai_fields_from_fallback` — fallback path generates fields
- `test_outcome_to_chat_completion_preserves_existing_openai_fields` — existing LLM fields are preserved

All 11 tests pass.

Fixes guardrails-ai/guardrails#1415