### PR TITLE
[GR-1710] chore: verify guardrails-ai-types 0.5.0

### DIFF
--- a/guardrails_api/app.py
+++ b/guardrails_api/app.py
@@ -11,7 +11,7 @@ from guardrails_api.db.postgres_client import postgres_is_enabled
 
 from rich.console import Console
 from rich.rule import Rule
-from typing import Optional
+from typing import Optional, cast
 import importlib.util
 import json
 import os
@@ -71,7 +71,7 @@ def register_middleware(*, middleware: Optional[str] = None, app: FastAPI):
                         and export != BaseHTTPMiddleware
                     )
                     if is_middleware:
-                        app.add_middleware(export)
+                        app.add_middleware(cast(type[BaseHTTPMiddleware], export))
         except Exception as e:
             raise RuntimeError(
                 f"Failed to register middleware from {middleware_file_path}", e

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -23,7 +23,7 @@ fsspec==2026.6.0
 googleapis-common-protos==1.75.0
 grpcio==1.81.1
 guardrails-ai==0.10.2
-guardrails-ai-types==0.4.0
+guardrails-ai-types==0.5.0
 guardrails_hub_types==0.0.4
 h11==0.16.0
 hf-xet==1.5.1


### PR DESCRIPTION
Draft — for CI signal only. Verifies that **guardrails-ai-types 0.5.0** doesn't break `guardrails-api`. Bumps `requirements-lock.txt` `0.4.0` → `0.5.0`. (CI installs fresh from `pyproject` via `guardrails-ai-types>=0.4.0`, so it resolves `0.5.0` regardless; this keeps the deploy lock in sync.)

Checklist (from the review on the types PR):
- [x] integration_tests.yml
- [x] pr_qa.yml

⚠️ Heads-up: `integration_tests.yml` still runs `guardrails hub install hub://guardrails/two_words` (the deprecated hub path), which may fail independently of this types bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)