### PR TITLE
[GR-1710] fix: cast middleware class to satisfy pyright

### DIFF
--- a/guardrails_api/app.py
+++ b/guardrails_api/app.py
@@ -11,7 +11,7 @@ from guardrails_api.db.postgres_client import postgres_is_enabled
 
 from rich.console import Console
 from rich.rule import Rule
-from typing import Optional
+from typing import Optional, cast
 import importlib.util
 import json
 import os
@@ -71,7 +71,7 @@ def register_middleware(*, middleware: Optional[str] = None, app: FastAPI):
                         and export != BaseHTTPMiddleware
                     )
                     if is_middleware:
-                        app.add_middleware(export)
+                        app.add_middleware(cast(type[BaseHTTPMiddleware], export))
         except Exception as e:
             raise RuntimeError(
                 f"Failed to register middleware from {middleware_file_path}", e


### PR DESCRIPTION
`app.add_middleware(export)` fails pyright: `export` (from `getattr`) stays loosely typed even after the `issubclass(BaseHTTPMiddleware)` guard, so it can't be assigned to `middleware_class`. Cast to `type[BaseHTTPMiddleware]` (runtime already verifies it).

Pre-existing type error surfaced by current starlette/pyright — independent of the `guardrails-ai-types` 0.5.0 bump (verification of which is in #133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)